### PR TITLE
Fix the plugin to return nil instead of an error when API credentials are not set in the `*.spc` file

### DIFF
--- a/hubspot/utils.go
+++ b/hubspot/utils.go
@@ -45,14 +45,14 @@ func listAllPropertiesByObjectType(ctx context.Context, d *plugin.QueryData, obj
 	authorizer, err := connect(ctx, d)
 	if err != nil {
 		plugin.Logger(ctx).Error("listAllPropertiesByObjectType", "connection_error", err)
-		return nil, err
+		return []properties.Property{}, nil
 	}
 	context := hubspot.WithAuthorizer(context.Background(), authorizer)
 	client := properties.NewAPIClient(properties.NewConfiguration())
 	resp, _, err := client.CoreApi.GetAll(context, objectType).Execute()
 	if err != nil {
 		plugin.Logger(ctx).Error("listAllPropertiesByObjectType", "api_error", err)
-		return nil, err
+		return []properties.Property{}, nil
 	}
 
 	return resp.Results, nil


### PR DESCRIPTION


# Example query results
<details>
  <summary>Results</summary>

```
Add example SQL query results here (please include the input queries as well)
```
</details>
