### PR TITLE
Update the default dynamic column type to string

### DIFF
--- a/hubspot/utils.go
+++ b/hubspot/utils.go
@@ -71,6 +71,6 @@ func setDynamicColumnTypes(property properties.Property, column *plugin.Column) 
 	case "enumeration":
 		column.Type = proto.ColumnType_STRING
 	default:
-		column.Type = proto.ColumnType_JSON
+		column.Type = proto.ColumnType_STRING
 	}
 }


### PR DESCRIPTION
# Example query results
<details>
  <summary>Results</summary>

```
> select custom_date_picker from hubspot_contact;
+--------------------+
| custom_date_picker |
+--------------------+
| <null>             |
| <null>             |
| <null>             |
| 2024-02-05         |
+--------------------+
```
</details>
