### PR TITLE
Redesigned hubspot_ticket, hubspot_contact, hubspot_deal, and hubspot_company tables to fetch details based on SELECT statements Closes #32

### DIFF
--- a/hubspot/table_hubspot_company.go
+++ b/hubspot/table_hubspot_company.go
@@ -18,7 +18,7 @@ func tableHubSpotCompany(ctx context.Context, companyPropertiesColumns []propert
 		Name:        "hubspot_company",
 		Description: "List of HubSpot Companies.",
 		List: &plugin.ListConfig{
-			Hydrate: listCompanies(ctx, companyPropertiesColumns),
+			Hydrate: listCompanies,
 			KeyColumns: []*plugin.KeyColumn{
 				{
 					Name:    "archived",
@@ -27,7 +27,7 @@ func tableHubSpotCompany(ctx context.Context, companyPropertiesColumns []propert
 			},
 		},
 		Get: &plugin.GetConfig{
-			Hydrate:    getCompany(ctx, companyPropertiesColumns),
+			Hydrate:    getCompany,
 			KeyColumns: plugin.SingleColumn("id"),
 		},
 		Columns: commonColumns(companyColumns(companyPropertiesColumns, []*plugin.Column{
@@ -71,114 +71,98 @@ func tableHubSpotCompany(ctx context.Context, companyPropertiesColumns []propert
 
 //// LIST FUNCTION
 
-func listCompanies(ctx context.Context, companyPropertiesColumns []properties.Property) func(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
-	return func(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
-		authorizer, err := connect(ctx, d)
-		if err != nil {
-			plugin.Logger(ctx).Error("hubspot_company.listCompanies", "connection_error", err)
-			return nil, err
-		}
-		context := hubspot.WithAuthorizer(context.Background(), authorizer)
-		client := companies.NewAPIClient(companies.NewConfiguration())
-
-		// Limiting the results
-		var maxLimit int32 = 100
-		if d.QueryContext.Limit != nil {
-			limit := int32(*d.QueryContext.Limit)
-			if limit < maxLimit {
-				maxLimit = limit
-			}
-		}
-		var after string = ""
-		archived := false
-
-		if d.EqualsQuals["archived"] != nil {
-			archived = d.EqualsQuals["archived"].GetBoolValue()
-		}
-
-		// get all the property names
-		properties := []string{}
-		for _, property := range companyPropertiesColumns {
-			properties = append(properties, property.Name)
-		}
-
-		for {
-			if after == "" {
-				response, _, err := client.BasicApi.GetPage(context).Limit(maxLimit).Archived(archived).Properties(properties).Execute()
-				if err != nil {
-					plugin.Logger(ctx).Error("hubspot_company.listCompanies", "api_error", err)
-					return nil, err
-				}
-				for _, company := range response.Results {
-					d.StreamListItem(ctx, company)
-
-					// Context can be cancelled due to manual cancellation or the limit has been hit
-					if d.RowsRemaining(ctx) == 0 {
-						return nil, nil
-					}
-				}
-				if !response.Paging.HasNext() {
-					break
-				}
-				after = response.Paging.Next.After
-			} else {
-				response, _, err := client.BasicApi.GetPage(context).Limit(maxLimit).After(after).Archived(archived).Properties(properties).Execute()
-				if err != nil {
-					plugin.Logger(ctx).Error("hubspot_company.listCompanies", "api_error", err)
-					return nil, err
-				}
-				for _, company := range response.Results {
-					d.StreamListItem(ctx, company)
-
-					// Context can be cancelled due to manual cancellation or the limit has been hit
-					if d.RowsRemaining(ctx) == 0 {
-						return nil, nil
-					}
-				}
-				if !response.Paging.HasNext() {
-					break
-				}
-				after = response.Paging.Next.After
-			}
-		}
-
-		return nil, nil
+func listCompanies(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
+	authorizer, err := connect(ctx, d)
+	if err != nil {
+		plugin.Logger(ctx).Error("hubspot_company.listCompanies", "connection_error", err)
+		return nil, err
 	}
+	context := hubspot.WithAuthorizer(context.Background(), authorizer)
+	client := companies.NewAPIClient(companies.NewConfiguration())
+
+	// Limiting the results
+	var maxLimit int32 = 100
+	if d.QueryContext.Limit != nil {
+		limit := int32(*d.QueryContext.Limit)
+		if limit < maxLimit {
+			maxLimit = limit
+		}
+	}
+	var after string = ""
+	archived := false
+
+	if d.EqualsQuals["archived"] != nil {
+		archived = d.EqualsQuals["archived"].GetBoolValue()
+	}
+
+	for {
+		if after == "" {
+			response, _, err := client.BasicApi.GetPage(context).Limit(maxLimit).Archived(archived).Properties(d.QueryContext.Columns).Execute()
+			if err != nil {
+				plugin.Logger(ctx).Error("hubspot_company.listCompanies", "api_error", err)
+				return nil, err
+			}
+			for _, company := range response.Results {
+				d.StreamListItem(ctx, company)
+
+				// Context can be cancelled due to manual cancellation or the limit has been hit
+				if d.RowsRemaining(ctx) == 0 {
+					return nil, nil
+				}
+			}
+			if !response.Paging.HasNext() {
+				break
+			}
+			after = response.Paging.Next.After
+		} else {
+			response, _, err := client.BasicApi.GetPage(context).Limit(maxLimit).After(after).Archived(archived).Properties(d.QueryContext.Columns).Execute()
+			if err != nil {
+				plugin.Logger(ctx).Error("hubspot_company.listCompanies", "api_error", err)
+				return nil, err
+			}
+			for _, company := range response.Results {
+				d.StreamListItem(ctx, company)
+
+				// Context can be cancelled due to manual cancellation or the limit has been hit
+				if d.RowsRemaining(ctx) == 0 {
+					return nil, nil
+				}
+			}
+			if !response.Paging.HasNext() {
+				break
+			}
+			after = response.Paging.Next.After
+		}
+	}
+
+	return nil, nil
 }
 
 //// HYDRATE FUNCTIONS
 
-func getCompany(ctx context.Context, companyPropertiesColumns []properties.Property) func(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
-	return func(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
-		id := d.EqualsQualString("id")
+func getCompany(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
+	id := d.EqualsQualString("id")
 
-		// check if id is empty
-		if id == "" {
-			return nil, nil
-		}
-
-		// get all the property names
-		properties := []string{}
-		for _, property := range companyPropertiesColumns {
-			properties = append(properties, property.Name)
-		}
-
-		authorizer, err := connect(ctx, d)
-		if err != nil {
-			plugin.Logger(ctx).Error("hubspot_company.getCompany", "connection_error", err)
-			return nil, err
-		}
-		context := hubspot.WithAuthorizer(context.Background(), authorizer)
-		client := companies.NewAPIClient(companies.NewConfiguration())
-
-		company, _, err := client.BasicApi.GetByID(context, id).Properties(properties).Execute()
-		if err != nil {
-			plugin.Logger(ctx).Error("hubspot_company.getCompany", "api_error", err)
-			return nil, err
-		}
-
-		return *company, nil
+	// check if id is empty
+	if id == "" {
+		return nil, nil
 	}
+
+	authorizer, err := connect(ctx, d)
+	if err != nil {
+		plugin.Logger(ctx).Error("hubspot_company.getCompany", "connection_error", err)
+		return nil, err
+	}
+	context := hubspot.WithAuthorizer(context.Background(), authorizer)
+	client := companies.NewAPIClient(companies.NewConfiguration())
+
+	company, _, err := client.BasicApi.GetByID(context, id).Properties(d.QueryContext.Columns).Execute()
+	if err != nil {
+		plugin.Logger(ctx).Error("hubspot_company.getCompany", "api_error", err)
+		return nil, err
+	}
+
+	return *company, nil
 }
 
 func companyColumns(companyPropertiesColumns []properties.Property, columns []*plugin.Column) []*plugin.Column {
@@ -191,7 +175,7 @@ func setCompanyDynamicColumns(properties []properties.Property) []*plugin.Column
 		column := &plugin.Column{
 			Name:        property.Name,
 			Description: property.Description,
-			Transform: transform.FromP(extractCompanyProperties, property.Name),
+			Transform:   transform.FromP(extractCompanyProperties, property.Name),
 		}
 		setDynamicColumnTypes(property, column)
 		Columns = append(Columns, column)

--- a/hubspot/table_hubspot_ticket.go
+++ b/hubspot/table_hubspot_ticket.go
@@ -18,7 +18,7 @@ func tableHubSpotTicket(ctx context.Context, ticketPropertiesColumns []propertie
 		Name:        "hubspot_ticket",
 		Description: "List of HubSpot Tickets.",
 		List: &plugin.ListConfig{
-			Hydrate: listTickets(ctx, ticketPropertiesColumns),
+			Hydrate: listTickets,
 			KeyColumns: []*plugin.KeyColumn{
 				{
 					Name:    "archived",
@@ -27,7 +27,7 @@ func tableHubSpotTicket(ctx context.Context, ticketPropertiesColumns []propertie
 			},
 		},
 		Get: &plugin.GetConfig{
-			Hydrate:    getTicket(ctx, ticketPropertiesColumns),
+			Hydrate:    getTicket,
 			KeyColumns: plugin.SingleColumn("id"),
 		},
 		Columns: commonColumns(ticketColumns(ticketPropertiesColumns, []*plugin.Column{
@@ -71,114 +71,98 @@ func tableHubSpotTicket(ctx context.Context, ticketPropertiesColumns []propertie
 
 //// LIST FUNCTION
 
-func listTickets(ctx context.Context, ticketPropertiesColumns []properties.Property) func(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
-	return func(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
-		authorizer, err := connect(ctx, d)
-		if err != nil {
-			plugin.Logger(ctx).Error("hubspot_ticket.listTickets", "connection_error", err)
-			return nil, err
-		}
-		context := hubspot.WithAuthorizer(context.Background(), authorizer)
-		client := tickets.NewAPIClient(tickets.NewConfiguration())
-
-		// Limiting the results
-		var maxLimit int32 = 100
-		if d.QueryContext.Limit != nil {
-			limit := int32(*d.QueryContext.Limit)
-			if limit < maxLimit {
-				maxLimit = limit
-			}
-		}
-		var after string = ""
-		archived := false
-
-		if d.EqualsQuals["archived"] != nil {
-			archived = d.EqualsQuals["archived"].GetBoolValue()
-		}
-
-		// get all the property names
-		properties := []string{}
-		for _, property := range ticketPropertiesColumns {
-			properties = append(properties, property.Name)
-		}
-
-		for {
-			if after == "" {
-				response, _, err := client.BasicApi.GetPage(context).Limit(maxLimit).Archived(archived).Properties(properties).Execute()
-				if err != nil {
-					plugin.Logger(ctx).Error("hubspot_ticket.listTickets", "api_error", err)
-					return nil, err
-				}
-				for _, ticket := range response.Results {
-					d.StreamListItem(ctx, ticket)
-
-					// Context can be cancelled due to manual cancellation or the limit has been hit
-					if d.RowsRemaining(ctx) == 0 {
-						return nil, nil
-					}
-				}
-				if !response.Paging.HasNext() {
-					break
-				}
-				after = response.Paging.Next.After
-			} else {
-				response, _, err := client.BasicApi.GetPage(context).Limit(maxLimit).After(after).Archived(archived).Properties(properties).Execute()
-				if err != nil {
-					plugin.Logger(ctx).Error("hubspot_ticket.listTickets", "api_error", err)
-					return nil, err
-				}
-				for _, ticket := range response.Results {
-					d.StreamListItem(ctx, ticket)
-
-					// Context can be cancelled due to manual cancellation or the limit has been hit
-					if d.RowsRemaining(ctx) == 0 {
-						return nil, nil
-					}
-				}
-				if !response.Paging.HasNext() {
-					break
-				}
-				after = response.Paging.Next.After
-			}
-		}
-
-		return nil, nil
+func listTickets(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
+	authorizer, err := connect(ctx, d)
+	if err != nil {
+		plugin.Logger(ctx).Error("hubspot_ticket.listTickets", "connection_error", err)
+		return nil, err
 	}
+	context := hubspot.WithAuthorizer(context.Background(), authorizer)
+	client := tickets.NewAPIClient(tickets.NewConfiguration())
+
+	// Limiting the results
+	var maxLimit int32 = 100
+	if d.QueryContext.Limit != nil {
+		limit := int32(*d.QueryContext.Limit)
+		if limit < maxLimit {
+			maxLimit = limit
+		}
+	}
+	var after string = ""
+	archived := false
+
+	if d.EqualsQuals["archived"] != nil {
+		archived = d.EqualsQuals["archived"].GetBoolValue()
+	}
+
+	for {
+		if after == "" {
+			response, _, err := client.BasicApi.GetPage(context).Limit(maxLimit).Archived(archived).Properties(d.QueryContext.Columns).Execute()
+			if err != nil {
+				plugin.Logger(ctx).Error("hubspot_ticket.listTickets", "api_error", err)
+				return nil, err
+			}
+			for _, ticket := range response.Results {
+				d.StreamListItem(ctx, ticket)
+
+				// Context can be cancelled due to manual cancellation or the limit has been hit
+				if d.RowsRemaining(ctx) == 0 {
+					return nil, nil
+				}
+			}
+			if !response.Paging.HasNext() {
+				break
+			}
+			after = response.Paging.Next.After
+		} else {
+			response, _, err := client.BasicApi.GetPage(context).Limit(maxLimit).After(after).Archived(archived).Properties(d.QueryContext.Columns).Execute()
+			if err != nil {
+				plugin.Logger(ctx).Error("hubspot_ticket.listTickets", "api_error", err)
+				return nil, err
+			}
+			for _, ticket := range response.Results {
+				d.StreamListItem(ctx, ticket)
+
+				// Context can be cancelled due to manual cancellation or the limit has been hit
+				if d.RowsRemaining(ctx) == 0 {
+					return nil, nil
+				}
+			}
+			if !response.Paging.HasNext() {
+				break
+			}
+			after = response.Paging.Next.After
+		}
+	}
+
+	return nil, nil
 }
 
 //// HYDRATE FUNCTIONS
 
-func getTicket(ctx context.Context, ticketPropertiesColumns []properties.Property) func(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
-	return func(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
-		id := d.EqualsQualString("id")
+func getTicket(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
+	id := d.EqualsQualString("id")
 
-		// check if id is empty
-		if id == "" {
-			return nil, nil
-		}
-
-		// get all the property names
-		properties := []string{}
-		for _, property := range ticketPropertiesColumns {
-			properties = append(properties, property.Name)
-		}
-
-		authorizer, err := connect(ctx, d)
-		if err != nil {
-			plugin.Logger(ctx).Error("hubspot_ticket.getTicket", "connection_error", err)
-			return nil, err
-		}
-		context := hubspot.WithAuthorizer(context.Background(), authorizer)
-		client := tickets.NewAPIClient(tickets.NewConfiguration())
-
-		ticket, _, err := client.BasicApi.GetByID(context, id).Properties(properties).Execute()
-		if err != nil {
-			plugin.Logger(ctx).Error("hubspot_ticket.getTicket", "api_error", err)
-			return nil, err
-		}
-
-		return ticket, nil
+	// check if id is empty
+	if id == "" {
+		return nil, nil
 	}
+
+	authorizer, err := connect(ctx, d)
+	if err != nil {
+		plugin.Logger(ctx).Error("hubspot_ticket.getTicket", "connection_error", err)
+		return nil, err
+	}
+	context := hubspot.WithAuthorizer(context.Background(), authorizer)
+	client := tickets.NewAPIClient(tickets.NewConfiguration())
+
+	ticket, _, err := client.BasicApi.GetByID(context, id).Properties(d.QueryContext.Columns).Execute()
+	if err != nil {
+		plugin.Logger(ctx).Error("hubspot_ticket.getTicket", "api_error", err)
+		return nil, err
+	}
+
+	return ticket, nil
 }
 
 func ticketColumns(ticketPropertiesColumns []properties.Property, columns []*plugin.Column) []*plugin.Column {
@@ -191,7 +175,7 @@ func setTicketDynamicColumns(properties []properties.Property) []*plugin.Column 
 		column := &plugin.Column{
 			Name:        property.Name,
 			Description: property.Description,
-			Transform: transform.FromP(extractTicketProperties, property.Name),
+			Transform:   transform.FromP(extractTicketProperties, property.Name),
 		}
 		setDynamicColumnTypes(property, column)
 		Columns = append(Columns, column)


### PR DESCRIPTION

# Example query results
<details>
  <summary>Results</summary>

### Earlier(Query Execution Time : 1.0s)

```
> select id from hubspot_contact
+-------------+
| id          |
+-------------+
| 60141886887 |
| 60144160905 |
| 60141414245 |
+-------------+

Time: 1.0s. Rows returned: 3. Rows fetched: 3. Hydrate calls: 0.
```

### Now(Query Execution Time: 476ms)

```
> select id from hubspot_contact
+-------------+
| id          |
+-------------+
| 60144160905 |
| 60141886887 |
| 60141414245 |
+-------------+

Time: 476ms. Rows returned: 3. Rows fetched: 3. Hydrate calls: 0.
```
</details>
